### PR TITLE
TAP-2755 Add missing links and documentation formatting for 2020.1

### DIFF
--- a/AAS/README.md
+++ b/AAS/README.md
@@ -4,4 +4,4 @@ Atlas Advanced Streams is the transportation protocol over Kafka/MQTT used by MT
 
 ### Versions
 - [**MTAP 2019.2.x and before**](2019.1/README.md)<br>
-- [**MTAP 2020.1.x and after**](2020.1/README.md)<br>
+- [**MTAP 2020.1**](2020.1/README.md)<br>

--- a/InfluxWriter/README.md
+++ b/InfluxWriter/README.md
@@ -4,4 +4,5 @@ Telemetry data and metadata about sessions are saved to various storage implemen
 
 ### Versions
 - [**0.10.2 and before**](0.10.2/README.md)<br>
-- [**MTAP 2019.1.0 and later**](2019.1.0/README.md)<br>
+- [**MTAP 2019.1.0**](2019.1.0/README.md)<br>
+- [**MTAP 2020.1**](2020.1/README.md)<br>

--- a/ParameterMapping/README.md
+++ b/ParameterMapping/README.md
@@ -4,4 +4,5 @@ The Parameter Mapping Service translates parameter names according to a configur
 The translation is done only on the configured parameters and all others are written to the target stream with the source stream name.
 
 ### Versions
-- [**MTAP 2019.2 and later**](2019.2/README.md)<br>
+- [**MTAP 2019.2**](2019.2/README.md)<br>
+- [**MTAP 2020.1**](2020.1/README.md)<br>

--- a/ReplayService/README.md
+++ b/ReplayService/README.md
@@ -3,4 +3,5 @@
 Replay Service allows the replay of historical sessions from [TAP API](/TAPApi/README.md) as if they were live again. The service allows for custom using custom data selection for replay, e.g. specify a subset of the parameters.
 
 ### Versions
-- [**MTAP 2019.2 and later**](2019.2/README.md)<br>
+- [**MTAP 2019.2**](2019.2/README.md)<br>
+- [**MTAP 2020.1**](2020.1/README.md)<br>

--- a/SignalR/README.md
+++ b/SignalR/README.md
@@ -4,4 +4,4 @@ SignalR is a service using websocket to push notifications about live data strea
 
 ### Versions
 - [**MTAP 2019.2**](2019.2/README.md)<br>
-- [**MTAP 2020.1 and later**](2020.1/README.md)<br>
+- [**MTAP 2020.1**](2020.1/README.md)<br>

--- a/TAPApi/README.md
+++ b/TAPApi/README.md
@@ -4,4 +4,5 @@ The Telemetry Analytics API (TAP API) service provides programmatic access to pe
 
 ### Versions
 - [**MTAP 2019.1.x and before**](2019.1/README.md)<br>
-- [**MTAP 2019.2 and later**](2019.2/README.md)<br>
+- [**MTAP 2019.2**](2019.2/README.md)<br>
+- [**MTAP 2020.1**](2020.1/README.md)<br>


### PR DESCRIPTION
Most of the homepage READMEs for the services were missing linkst o 2020.1