### PR TITLE
Task/minor fixes

### DIFF
--- a/AAS/2019.1/README.md
+++ b/AAS/2019.1/README.md
@@ -1,9 +1,9 @@
-# ![logo](/Media/branding.png) Atlas Advanced Stream
+# ![logo](/Media/branding.png) Atlas Advanced Streams
 
 ### Table of Contents
 - **Introduction**<br>
 - [**C# Samples**](./csharp/README.md)<br>
 - [**Python Samples**](./python/README.md)<br>
 
-Atlas Advanced Stream is the transportation protocol over Kafka/MQTT used by MTAP.
+Atlas Advanced Streams is the transportation protocol over Kafka/MQTT used by MTAP.
 Documentation for the protocol can be found at our [zendesk page](https://mclarenappliedtechnologies.zendesk.com/hc/en-us/categories/115000361553-MTAP-McLaren-Telemetry-Analytics-Platform).

--- a/AAS/2020.1/README.md
+++ b/AAS/2020.1/README.md
@@ -289,11 +289,12 @@ For convenience, there is the concept of a "default" feed, which has an empty na
 The telemetry data messages are not self-describing, which implies there is a dependency describing the data format.
 
 A data format can be defined using the library using a fluent builder syntax:
-
+```
 DataFormat.DefineFeed().
   Parameter(DataAggregateSelection.Avg, "vCar:Chassis").
   Parameters(DataAggregateSelection.Min | DataAggregateSelection.Max, "gLat:Chassis", "gLong:Chassis").
   BuildFormat();
+```
 
 In JSON this looks like:
 ```json

--- a/AAS/2020.1/README.md
+++ b/AAS/2020.1/README.md
@@ -137,7 +137,7 @@ The ATLAS Advanced Streams API separates messages by stream to feed them into yo
 
 #### Sessions
 
-Sessions are intended to be a close analogue of the ATLAS Session concept. A session represents a period of captured telemetry data. This could be a race, a test session or a journey
+Sessions are intended to be a close analogue of the ATLAS Session concept. A session represents a period of captured telemetry data. This could be a race, a test session or a journey.
 
 They are implemented on top of streams, which means that you can have multiple concurrent sessions in a topic, and that the API will separate the sessions to feed them into your code.
 

--- a/Helm/2019.2/README.md
+++ b/Helm/2019.2/README.md
@@ -2,7 +2,7 @@
 
 ## What is TAP Helm Charts
 
-[TAP Helm charts](https://github.com/mat-docs/mtap-docs/blob/master/Helm/README.md) allows you to define and deploy a functional TAP platform into the Kubernetes cluster with just an easy configuration file and a command-line.
+[TAP Helm charts](https://github.com/mat-docs/mtap-docs/blob/master/Helm/README.md) allows you to define and deploy a functional Telemetry Analytics Platform Platform into the Kubernetes cluster with just an easy configuration file and a command-line.
 
 Helm Charts helps you define, install, and upgrade even the most complex Kubernetes application. 
 
@@ -16,9 +16,9 @@ Helm Charts helps you define, install, and upgrade even the most complex Kuberne
 
 You will need a Kubernetes cluster and some basic knowledge about Kubernetes and Helm to be able to use these Helm charts.
 
-Apart from this, the TAP platform requires some external services to run properly:
+Apart from this, the Telemetry Analytics Platform Platform requires some external services to run properly:
 
-- Apache Kafka: Kafka is used as the message broker of our services. You will need to install an instance of Kafka separately and make it accessible from the Kubernetes cluster to be able to run the TAP platform.
+- Apache Kafka: Kafka is used as the message broker of our services. You will need to install an instance of Kafka separately and make it accessible from the Kubernetes cluster to be able to run the Telemetry Analytics Platform Platform.
 
 - InfluxDB database: One or more InfluxDB time-series databases to persist and query Telemetry data in the platform. The default Helm chart configuration uses a unique instance of this database but you can override easily the rest of the services to set up more than one InfluxDB instances. You can use your InfluxDB instances from outside the cluster or you can use the provided `mat.tap.requisites` helm chart to deploy several InfluxDB instances into the Kubernetes cluster.
 
@@ -67,7 +67,7 @@ Create `values.yaml` file to define the parameters of the cluster deployment. Th
 
 ### Global variables
 
-There is a Global section in the values yaml file to define common parameters to all the services of the TAP platform. Some of these parameters are essential to be able to run our platform, like Kafka broker, relational database or InfluxDB url.
+There is a Global section in the values yaml file to define common parameters to all the services of the Telemetry Analytics Platform Platform. Some of these parameters are essential to be able to run our platform, like Kafka broker, relational database or InfluxDB url.
 
 Example:
 
@@ -319,7 +319,7 @@ You can find more extensive documentation in [InfluxDb writer documentation](htt
 
 #### Configuring SignalR service
 
-SignalR service needs a list of Kafka topic names as an input configuration to be able to run properly in TAP platform. Use `topicNames` parameter to define this list of topics:
+SignalR service needs a list of Kafka topic names as an input configuration to be able to run properly in Telemetry Analytics Platform Platform. Use `topicNames` parameter to define this list of topics:
 
 ``` bash
 signalr:
@@ -385,7 +385,7 @@ The following tables list all the possible Global parameters of the TAP requisit
 
 ### TAP Requisites
 
-These charts help you to install some requisites services for TAP platform. You can use these Helm deployment or use your own services. This is the complete list of services deployable through this `mat.tap.requisites` charts:
+These charts help you to install some requisites services for Telemetry Analytics Platform Platform. You can use these Helm deployment or use your own services. This is the complete list of services deployable through this `mat.tap.requisites` charts:
 
 | Service | Description | Documentation |
 |-|-|-|

--- a/Helm/2019.2/README.md
+++ b/Helm/2019.2/README.md
@@ -2,7 +2,7 @@
 
 ## What is TAP Helm Charts
 
-[TAP Helm charts](https://github.com/mat-docs/mtap-docs/blob/master/Helm/README.md) allows you to define and deploy a functional Telemetry Analytics Platform Platform into the Kubernetes cluster with just an easy configuration file and a command-line.
+[TAP Helm charts](https://github.com/mat-docs/mtap-docs/blob/master/Helm/README.md) allows you to define and deploy a functional Telemetry Analytics Platform into the Kubernetes cluster with just an easy configuration file and a command-line.
 
 Helm Charts helps you define, install, and upgrade even the most complex Kubernetes application. 
 
@@ -16,9 +16,9 @@ Helm Charts helps you define, install, and upgrade even the most complex Kuberne
 
 You will need a Kubernetes cluster and some basic knowledge about Kubernetes and Helm to be able to use these Helm charts.
 
-Apart from this, the Telemetry Analytics Platform Platform requires some external services to run properly:
+Apart from this, the Telemetry Analytics Platform requires some external services to run properly:
 
-- Apache Kafka: Kafka is used as the message broker of our services. You will need to install an instance of Kafka separately and make it accessible from the Kubernetes cluster to be able to run the Telemetry Analytics Platform Platform.
+- Apache Kafka: Kafka is used as the message broker of our services. You will need to install an instance of Kafka separately and make it accessible from the Kubernetes cluster to be able to run the Telemetry Analytics Platform.
 
 - InfluxDB database: One or more InfluxDB time-series databases to persist and query Telemetry data in the platform. The default Helm chart configuration uses a unique instance of this database but you can override easily the rest of the services to set up more than one InfluxDB instances. You can use your InfluxDB instances from outside the cluster or you can use the provided `mat.tap.requisites` helm chart to deploy several InfluxDB instances into the Kubernetes cluster.
 
@@ -67,7 +67,7 @@ Create `values.yaml` file to define the parameters of the cluster deployment. Th
 
 ### Global variables
 
-There is a Global section in the values yaml file to define common parameters to all the services of the Telemetry Analytics Platform Platform. Some of these parameters are essential to be able to run our platform, like Kafka broker, relational database or InfluxDB url.
+There is a Global section in the values yaml file to define common parameters to all the services of the Telemetry Analytics Platform. Some of these parameters are essential to be able to run our platform, like Kafka broker, relational database or InfluxDB url.
 
 Example:
 
@@ -319,7 +319,7 @@ You can find more extensive documentation in [InfluxDb writer documentation](htt
 
 #### Configuring SignalR service
 
-SignalR service needs a list of Kafka topic names as an input configuration to be able to run properly in Telemetry Analytics Platform Platform. Use `topicNames` parameter to define this list of topics:
+SignalR service needs a list of Kafka topic names as an input configuration to be able to run properly in Telemetry Analytics Platform. Use `topicNames` parameter to define this list of topics:
 
 ``` bash
 signalr:
@@ -385,7 +385,7 @@ The following tables list all the possible Global parameters of the TAP requisit
 
 ### TAP Requisites
 
-These charts help you to install some requisites services for Telemetry Analytics Platform Platform. You can use these Helm deployment or use your own services. This is the complete list of services deployable through this `mat.tap.requisites` charts:
+These charts help you to install some requisites services for Telemetry Analytics Platform. You can use these Helm deployment or use your own services. This is the complete list of services deployable through this `mat.tap.requisites` charts:
 
 | Service | Description | Documentation |
 |-|-|-|

--- a/Helm/2020.1/README.md
+++ b/Helm/2020.1/README.md
@@ -1,6 +1,6 @@
 ## What is TAP Helm Charts
 
-[TAP Helm charts](https://github.com/mat-docs/mtap-docs/blob/master/Helm/README.md) allows you to define and deploy a functional Telemetry Analytics Platform Platform into the Kubernetes cluster with just an easy configuration file and a command-line.
+[TAP Helm charts](https://github.com/mat-docs/mtap-docs/blob/master/Helm/README.md) allows you to define and deploy a functional Telemetry Analytics Platform into the Kubernetes cluster with just an easy configuration file and a command-line.
 
 Helm Charts helps you define, install, and upgrade even the most complex Kubernetes application. 
 
@@ -8,9 +8,9 @@ Helm Charts helps you define, install, and upgrade even the most complex Kuberne
 
 You will need a Kubernetes cluster and some basic knowledge about Kubernetes and Helm to be able to use these Helm charts.
 
-Apart from this, the Telemetry Analytics Platform Platform requires some external services to run properly:
+Apart from this, the Telemetry Analytics Platform requires some external services to run properly:
 
-- Apache Kafka: Kafka is used as the message broker of our services. You will need to install an instance of Kafka separately and make it accessible from the Kubernetes cluster to be able to run the Telemetry Analytics Platform Platform.
+- Apache Kafka: Kafka is used as the message broker of our services. You will need to install an instance of Kafka separately and make it accessible from the Kubernetes cluster to be able to run the Telemetry Analytics Platform.
 
 - InfluxDB database: One or more InfluxDB time-series databases to persist and query Telemetry data in the platform. The default Helm chart configuration uses a unique instance of this database but you can override easily the rest of the services to set up more than one InfluxDB instances. You can use your InfluxDB instances from outside the cluster or you can use the provided `mat.tap.requisites` helm chart to deploy several InfluxDB instances into the Kubernetes cluster.
 
@@ -59,7 +59,7 @@ Create `values.yaml` file to define the parameters of the cluster deployment. Th
 
 ### Global variables
 
-There is a Global section in the values yaml file to define common parameters to all the services of the Telemetry Analytics Platform Platform. Some of these parameters are essential to be able to run our platform, like Kafka broker, relational database or InfluxDB url.
+There is a Global section in the values yaml file to define common parameters to all the services of the Telemetry Analytics Platform. Some of these parameters are essential to be able to run our platform, like Kafka broker, relational database or InfluxDB url.
 
 Example:
 
@@ -313,7 +313,7 @@ You can find more extensive documentation in [InfluxDb writer documentation](htt
 
 #### Configuring SignalR service
 
-SignalR service needs a list of Kafka topic names as an input configuration to be able to run properly in Telemetry Analytics Platform Platform. Use `topicNames` parameter to define this list of topics:
+SignalR service needs a list of Kafka topic names as an input configuration to be able to run properly in Telemetry Analytics Platform. Use `topicNames` parameter to define this list of topics:
 
 ``` bash
 signalr:
@@ -379,7 +379,7 @@ The following tables list all the possible Global parameters of the TAP requisit
 
 ### TAP Requisites
 
-These charts help you to install some requisites services for Telemetry Analytics Platform Platform. You can use these Helm deployment or use your own services. This is the complete list of services deployable through this `mat.tap.requisites` charts:
+These charts help you to install some requisites services for Telemetry Analytics Platform. You can use these Helm deployment or use your own services. This is the complete list of services deployable through this `mat.tap.requisites` charts:
 
 | Service | Description | Documentation |
 |-|-|-|

--- a/Helm/2020.1/README.md
+++ b/Helm/2020.1/README.md
@@ -1,6 +1,6 @@
 ## What is TAP Helm Charts
 
-[TAP Helm charts](https://github.com/mat-docs/mtap-docs/blob/master/Helm/README.md) allows you to define and deploy a functional TAP platform into the Kubernetes cluster with just an easy configuration file and a command-line.
+[TAP Helm charts](https://github.com/mat-docs/mtap-docs/blob/master/Helm/README.md) allows you to define and deploy a functional Telemetry Analytics Platform Platform into the Kubernetes cluster with just an easy configuration file and a command-line.
 
 Helm Charts helps you define, install, and upgrade even the most complex Kubernetes application. 
 
@@ -8,9 +8,9 @@ Helm Charts helps you define, install, and upgrade even the most complex Kuberne
 
 You will need a Kubernetes cluster and some basic knowledge about Kubernetes and Helm to be able to use these Helm charts.
 
-Apart from this, the TAP platform requires some external services to run properly:
+Apart from this, the Telemetry Analytics Platform Platform requires some external services to run properly:
 
-- Apache Kafka: Kafka is used as the message broker of our services. You will need to install an instance of Kafka separately and make it accessible from the Kubernetes cluster to be able to run the TAP platform.
+- Apache Kafka: Kafka is used as the message broker of our services. You will need to install an instance of Kafka separately and make it accessible from the Kubernetes cluster to be able to run the Telemetry Analytics Platform Platform.
 
 - InfluxDB database: One or more InfluxDB time-series databases to persist and query Telemetry data in the platform. The default Helm chart configuration uses a unique instance of this database but you can override easily the rest of the services to set up more than one InfluxDB instances. You can use your InfluxDB instances from outside the cluster or you can use the provided `mat.tap.requisites` helm chart to deploy several InfluxDB instances into the Kubernetes cluster.
 
@@ -59,7 +59,7 @@ Create `values.yaml` file to define the parameters of the cluster deployment. Th
 
 ### Global variables
 
-There is a Global section in the values yaml file to define common parameters to all the services of the TAP platform. Some of these parameters are essential to be able to run our platform, like Kafka broker, relational database or InfluxDB url.
+There is a Global section in the values yaml file to define common parameters to all the services of the Telemetry Analytics Platform Platform. Some of these parameters are essential to be able to run our platform, like Kafka broker, relational database or InfluxDB url.
 
 Example:
 
@@ -313,7 +313,7 @@ You can find more extensive documentation in [InfluxDb writer documentation](htt
 
 #### Configuring SignalR service
 
-SignalR service needs a list of Kafka topic names as an input configuration to be able to run properly in TAP platform. Use `topicNames` parameter to define this list of topics:
+SignalR service needs a list of Kafka topic names as an input configuration to be able to run properly in Telemetry Analytics Platform Platform. Use `topicNames` parameter to define this list of topics:
 
 ``` bash
 signalr:
@@ -379,7 +379,7 @@ The following tables list all the possible Global parameters of the TAP requisit
 
 ### TAP Requisites
 
-These charts help you to install some requisites services for TAP platform. You can use these Helm deployment or use your own services. This is the complete list of services deployable through this `mat.tap.requisites` charts:
+These charts help you to install some requisites services for Telemetry Analytics Platform Platform. You can use these Helm deployment or use your own services. This is the complete list of services deployable through this `mat.tap.requisites` charts:
 
 | Service | Description | Documentation |
 |-|-|-|

--- a/Helm/README.md
+++ b/Helm/README.md
@@ -1,6 +1,6 @@
 # ![logo](/Media/branding.png) TAP Helm charts
 
-TAP Helm charts allows you to define and deploy a functional TAP platform into the Kubernetes cluster with just an easy configuration file and a command-line.
+TAP Helm charts allows you to define and deploy a functional Telemetry Analytics Platform Platform into the Kubernetes cluster with just an easy configuration file and a command-line.
 
 ### Versions
 - [**MTAP 2019.2 and later**](2019.2/README.md)<br>

--- a/Helm/README.md
+++ b/Helm/README.md
@@ -1,6 +1,6 @@
 # ![logo](/Media/branding.png) TAP Helm charts
 
-TAP Helm charts allows you to define and deploy a functional Telemetry Analytics Platform Platform into the Kubernetes cluster with just an easy configuration file and a command-line.
+TAP Helm charts allows you to define and deploy a functional Telemetry Analytics Platform into the Kubernetes cluster with just an easy configuration file and a command-line.
 
 ### Versions
 - [**MTAP 2019.2 and later**](2019.2/README.md)<br>

--- a/IdentityService/2019.1/docs/Installation.md
+++ b/IdentityService/2019.1/docs/Installation.md
@@ -12,7 +12,7 @@
 
 ## Run with Docker
 
-Identity service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/beta/#/mclarenappliedtechnologies/mtap/identity-service?tab=readme).
+Identity service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/beta/#/mclarenappliedtechnologies/mtap/identity-service?tab=readme) (requires login to bintray).
 
 
 ## .NET Core runtime dependency

--- a/InfluxWriter/2019.1.0/docs/Installation.md
+++ b/InfluxWriter/2019.1.0/docs/Installation.md
@@ -53,7 +53,7 @@ sudo apt-get --yes install aspnetcore-runtime-2.1
 
 ## Run with Docker
 
-Influx Writer is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/beta/#/mclarenappliedtechnologies/mtap/influx-writer-service?tab=readme).
+Influx Writer is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/beta/#/mclarenappliedtechnologies/mtap/influx-writer-service?tab=readme) (requires login to bintray).
 
 ## Run as standalone
 

--- a/InfluxWriter/2020.1/docs/Installation.md
+++ b/InfluxWriter/2020.1/docs/Installation.md
@@ -53,7 +53,7 @@ sudo apt-get --yes install aspnetcore-runtime-2.1
 
 ## Run with Docker
 
-Influx Writer is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/beta/#/mclarenappliedtechnologies/mtap/influx-writer-service?tab=readme).
+Influx Writer is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/beta/#/mclarenappliedtechnologies/mtap/influx-writer-service?tab=readme) (requires login to bintray).
 
 ## Run as standalone
 

--- a/ParameterMapping/2019.2/docs/Installation.md
+++ b/ParameterMapping/2019.2/docs/Installation.md
@@ -9,7 +9,7 @@
 
 ## Run with Docker
 
-Parameter Mapping service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/parametermapping-service#read) (requires login to bintray).
+Parameter Mapping service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/parameter-mapping-service#read) (requires login to bintray).
 
 ## Run as a daemon service
 ### .NET Core runtime dependency

--- a/ParameterMapping/2019.2/docs/Installation.md
+++ b/ParameterMapping/2019.2/docs/Installation.md
@@ -9,7 +9,7 @@
 
 ## Run with Docker
 
-Parameter Mapping service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/parametermapping-service#read).
+Parameter Mapping service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/parametermapping-service#read) (requires login to bintray).
 
 ## Run as a daemon service
 ### .NET Core runtime dependency

--- a/ParameterMapping/2019.2/docs/ServiceConfig.md
+++ b/ParameterMapping/2019.2/docs/ServiceConfig.md
@@ -9,6 +9,7 @@
 [Identity Service]: /IdentityService/README.md
 [cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 [protobuf]: https://mclarenappliedtechnologies.zendesk.com/hc/en-us/articles/360008375233-Protobuf-Extension
+[dependency service]: https://mclarenappliedtechnologies.zendesk.com/hc/en-us/articles/115003531373-API-Reference-Dependencies-Service
 
 The configuration file of the service is called ```appsettings.json```
 <details>

--- a/ParameterMapping/2020.1/docs/Installation.md
+++ b/ParameterMapping/2020.1/docs/Installation.md
@@ -9,7 +9,7 @@
 
 ## Run with Docker
 
-Parameter Mapping service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/parametermapping-service#read) (requires login to bintray).
+Parameter Mapping service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/parameter-mapping-service#read) (requires login to bintray).
 
 ## Run as a daemon service
 ### .NET Core runtime dependency

--- a/ParameterMapping/2020.1/docs/Installation.md
+++ b/ParameterMapping/2020.1/docs/Installation.md
@@ -9,7 +9,7 @@
 
 ## Run with Docker
 
-Parameter Mapping service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/parametermapping-service#read).
+Parameter Mapping service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/parametermapping-service#read) (requires login to bintray).
 
 ## Run as a daemon service
 ### .NET Core runtime dependency

--- a/ParameterMapping/2020.1/docs/ServiceConfig.md
+++ b/ParameterMapping/2020.1/docs/ServiceConfig.md
@@ -9,6 +9,7 @@
 [Identity Service]: /IdentityService/README.md
 [cors]: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
 [protobuf]: https://mclarenappliedtechnologies.zendesk.com/hc/en-us/articles/360008375233-Protobuf-Extension
+[dependency service]: https://mclarenappliedtechnologies.zendesk.com/hc/en-us/articles/115003531373-API-Reference-Dependencies-Service
 
 The configuration file of the service is called ```appsettings.json```
 <details>

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Includes connectivity services for wideband, SQL Race databases, an ATLAS 10 rec
 These capabilities work together to create an integrated experience: ATLAS Advanced Streams carries data from the ECU, models and other racing applications, and the Telemetry Analytics API includes a service to feed this data live into InfluxDB for search and dashboarding.
 
 ### Table of Contents
-- [**Atlas Advanced Stream**](/AAS/README.md)<br>
+- [**Atlas Advanced Streams**](/AAS/README.md)<br>
 - [**Influx Writer**](/InfluxWriter/README.md)<br>
 - [**Parameter Mapping**](/ParameterMapping/README.md)<br>
 - [**Replay Service**](ReplayService/README.md)<br>

--- a/ReplayService/2019.2/docs/Installation.md
+++ b/ReplayService/2019.2/docs/Installation.md
@@ -11,7 +11,7 @@
 
 ## Run with Docker
 
-Replay Service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/replay-service#read).
+Replay Service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/replay-service#read) (requires login to bintray).
 
 ## Run as a daemon service
 ### .NET Core runtime dependency

--- a/ReplayService/2020.1/docs/Installation.md
+++ b/ReplayService/2020.1/docs/Installation.md
@@ -11,7 +11,7 @@
 
 ## Run with Docker
 
-Replay Service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/replay-service#read).
+Replay Service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/replay-service#read) (requires login to bintray).
 
 ## Run as a daemon service
 ### .NET Core runtime dependency

--- a/SignalR/2019.2/docs/Installation.md
+++ b/SignalR/2019.2/docs/Installation.md
@@ -10,7 +10,7 @@
 
 ## Run with Docker
 
-SignalR service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/signalr-service#read).
+SignalR service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/signalr-service#read) (requires login to bintray).
 
 ## Run as a daemon service
 ### .NET Core runtime dependency

--- a/SignalR/2020.1/docs/Installation.md
+++ b/SignalR/2020.1/docs/Installation.md
@@ -10,7 +10,7 @@
 
 ## Run with Docker
 
-SignalR service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/signalr-service#read).
+SignalR service is shipped as a docker image. For detailed instruction steps, please visit the [docker image hosted on bintray](https://bintray.com/mclarenappliedtechnologies/mtap/signalr-service#read) (requires login to bintray).
 
 ## Run as a daemon service
 ### .NET Core runtime dependency

--- a/TAPApi/2019.1/docs/Installation.md
+++ b/TAPApi/2019.1/docs/Installation.md
@@ -21,7 +21,7 @@ The [**Identity Service**](/IdentityService/README.md) must be installed before 
 
 #### Deploy the Docker Container
 For production usage we recommend using the Docker containers downloadable here:
-https://bintray.com/beta/#/mclarenappliedtechnologies/mtap/tapi-influx-service?tab=readme
+https://bintray.com/beta/#/mclarenappliedtechnologies/mtap/tapi-influx-service?tab=readme (requires login to bintray)
 
 #### Basic usage
 The API can be started from a console in Windows or Linux. This is useful for initial experimentation and familiarisation.

--- a/TAPApi/2019.2/docs/Installation.md
+++ b/TAPApi/2019.2/docs/Installation.md
@@ -21,7 +21,7 @@ The [**Identity Service**](/IdentityService/README.md) must be installed before 
 
 #### Deploy the Docker Container
 For production usage we recommend using the Docker containers downloadable here:
-https://bintray.com/beta/#/mclarenappliedtechnologies/mtap/tapi-influx-service?tab=readme
+https://bintray.com/beta/#/mclarenappliedtechnologies/mtap/tapi-influx-service?tab=readme (requires login to bintray)
 
 #### Basic usage
 The API can be started from a console in Windows or Linux. This is useful for initial experimentation and familiarisation.

--- a/TAPApi/2020.1/docs/Installation.md
+++ b/TAPApi/2020.1/docs/Installation.md
@@ -22,7 +22,7 @@ The [**Identity Service**](/IdentityService/README.md) must be installed before 
 
 #### Deploy the Docker Container
 For production usage we recommend using the Docker containers downloadable here:
-https://bintray.com/beta/#/mclarenappliedtechnologies/mtap/tapi-influx-service?tab=readme
+https://bintray.com/beta/#/mclarenappliedtechnologies/mtap/tapi-influx-service?tab=readme (requires login to bintray)
 
 #### Basic usage
 The API can be started from a console in Windows or Linux. This is useful for initial experimentation and familiarisation.


### PR DESCRIPTION
- fix spelling of AAS
- fix missing full stop
- Unabbreviate 'TAP platform' in Helm README
- fix missing link to dependency service
- mark the need for login to access bintray readmes